### PR TITLE
Refactor search forms layout

### DIFF
--- a/search/static/assets/css/custom.css
+++ b/search/static/assets/css/custom.css
@@ -1,0 +1,49 @@
+:root {
+  --primary-color: #ff5733;
+  --primary-hover-color: #c70039;
+  --header-bg: #2c3e50;
+  --header-text: #ffffff;
+  --body-bg: #f0f0f0;
+}
+
+body {
+  background: var(--body-bg);
+  font-family: 'Roboto', sans-serif;
+}
+
+.header {
+  background-color: var(--header-bg);
+  color: var(--header-text);
+}
+
+.header .toggle-sidebar-btn {
+  color: var(--header-text);
+}
+
+a {
+  color: var(--primary-color);
+}
+
+a:hover {
+  color: var(--primary-hover-color);
+}
+
+.sidebar {
+  background-color: #ffffff;
+}
+
+/* Layout for redesigned forms */
+.form-layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.form-layout .query-options {
+  flex: 1 1 250px;
+}
+
+.form-layout .query-input {
+  flex: 2 1 60%;
+}

--- a/search/templates/base.html
+++ b/search/templates/base.html
@@ -17,7 +17,7 @@
 
   <!-- Google Fonts -->
   <link href="https://fonts.gstatic.com" rel="preconnect">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i.Nunito:300,300i,400,400i,600,600i,700,700i.Poppins:300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i.Nunito:300,300i,400,400i,600,600i,700,700i.Poppins:300,300i,400,400i,500,500i,600,600i,700,700i&family=Roboto:300,400,500,700" rel="stylesheet">
 
   <!-- sql-formatter -->
   <script src="https://cdn.jsdelivr.net/npm/sql-formatter@4.0.2/dist/sql-formatter.min.js"></script>
@@ -58,7 +58,8 @@
   <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 
   <!-- Template Main CSS File -->
-  <link rel="stylesheet" href="{% static 'assets/css/style.css' %}"> 
+  <link rel="stylesheet" href="{% static 'assets/css/style.css' %}">
+  <link rel="stylesheet" href="{% static 'assets/css/custom.css' %}">
 
   <!-- HISTORY jqery -->
   <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.5/css/dataTables.bootstrap4.min.css"/>

--- a/search/templates/search/index.html
+++ b/search/templates/search/index.html
@@ -28,8 +28,9 @@
               <!-- <h5 class="card-title">Catopus search engine</h5> -->
     
               <!-- General Form Elements -->
-              <form method="post" id="query-form">
+              <form method="post" id="query-form" class="form-layout">
                 {% csrf_token %}
+                <div class="query-options">
 
 
                 <!-- Extra Large Modal -->
@@ -624,8 +625,10 @@
                     </div>
                   </div>
                   
-                </div>
-                <!-- Loading spinner -->
+                  </div>
+                </div><!-- query-options -->
+                <div class="query-input">
+                  <!-- Loading spinner -->
                 <div id="loader" class="text-center" style="display:none;">
                   <div class="d-flex justify-content-center">
                     <div>
@@ -636,18 +639,19 @@
                   </div>
                 </div>
 
-                <div id="saveToDbLoader" class="text-center" style="display:none;">
-                  <div class="d-flex justify-content-center">
-                    <div>
-                      <strong>Saving data...</strong>
-                    </div>
-                    <div class="spinner-border" style="width: 1.5rem; height: 1.5rem;" role="status">
+                  <div id="saveToDbLoader" class="text-center" style="display:none;">
+                    <div class="d-flex justify-content-center">
+                      <div>
+                        <strong>Saving data...</strong>
+                      </div>
+                      <div class="spinner-border" style="width: 1.5rem; height: 1.5rem;" role="status">
+                      </div>
                     </div>
                   </div>
-                </div>
-                <!-- Loading spinner -->
-              </form>
-              <!-- End General Form Elements -->
+                  <!-- Loading spinner -->
+                </div><!-- query-input -->
+                </form>
+                <!-- End General Form Elements -->
             </div>
 
           </div>

--- a/search/templates/search/index_archive.html
+++ b/search/templates/search/index_archive.html
@@ -247,8 +247,9 @@
               <!-- <h5 class="card-title">Catopus search engine</h5> -->
     
               <!-- General Form Elements -->
-              <form method="post" id="query-form">
+              <form method="post" id="query-form" class="form-layout">
                 {% csrf_token %}
+                <div class="query-options">
 
 
                 <!-- Extra Large Modal -->
@@ -765,9 +766,11 @@
 
                     </div>
                   </div>
-                  
-                </div>
-                <!-- Loading spinner -->
+
+                  </div>
+                </div><!-- query-options -->
+                <div class="query-input">
+                  <!-- Loading spinner -->
                 <div id="loader" class="text-center" style="display:none;">
                   <div class="d-flex justify-content-center">
                     <div>
@@ -787,8 +790,9 @@
                     </div>
                   </div>
                 </div>
-                <!-- Loading spinner -->
-              </form>
+                  <!-- Loading spinner -->
+                </div><!-- query-input -->
+                </form>
               <!-- End General Form Elements -->
             </div>
 


### PR DESCRIPTION
## Summary
- apply flexbox-based layout to search forms
- group buttons and textarea with new CSS classes
- update templates to use `.form-layout`, `.query-options`, and `.query-input` wrappers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ff594ef9c8321bad7090388c23532