### PR TITLE
Fix LoginCreds table reference

### DIFF
--- a/account/migrations/0002_initial.py
+++ b/account/migrations/0002_initial.py
@@ -35,8 +35,8 @@ class Migration(migrations.Migration):
                 ("is_staff", models.BooleanField(default=False)),
             ],
             options={
-                "db_table": 'dwh_system"."cat_login_creds',
-                "managed": False,
+                "db_table": '"dwh_system"."cat_login_creds"',
+                "managed": True,
             },
         ),
     ]

--- a/account/models.py
+++ b/account/models.py
@@ -24,8 +24,8 @@ class LoginCreds(AbstractBaseUser, PermissionsMixin):
     REQUIRED_FIELDS = []
 
     class Meta:
-        managed = False
-        db_table = 'dwh_system\".\"cat_login_creds'
+        managed = True
+        db_table = '"dwh_system"."cat_login_creds"'
 
     def __str__(self):
         return self.username


### PR DESCRIPTION
## Summary
- fix `db_table` for `LoginCreds`
- allow Django migrations to manage the `LoginCreds` table

## Testing
- `python manage.py check`
- `python -m compileall -q account`

------
https://chatgpt.com/codex/tasks/task_e_683ff93920b88321ab5ec595564fe560